### PR TITLE
Add Docker authentication to CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,13 @@
-version: 2
+version: 2.1
 
 jobs:
+
   build_deploy:
     docker:
       - image: circleci/node:10
+        auth:
+          username: $DOCKERHUB_USER
+          password: $DOCKERHUB_PASSWORD
     working_directory: ~/mediasuite.co.nz
     steps:
       - checkout
@@ -41,8 +45,9 @@ jobs:
             - "de:7b:22:2c:42:22:97:fe:f0:68:df:f1:38:2c:58:c2"
       - run:
           name: Add host to ssh config
+          # '<<' must be escaped in CircleCI 2.1
           command: |
-            cat >> ~/.ssh/config <<-EOF
+            cat >> ~/.ssh/config \<<-EOF
             Host mediasuite.co.nz
               HostName $RSYNC_HOST
               User $RSYNC_USER
@@ -54,9 +59,12 @@ jobs:
 
 workflows:
   version: 2
+
   build_deploy:
     jobs:
       - build_deploy:
+          context:
+            - docker-hub-creds
           filters:
             branches:
               only:


### PR DESCRIPTION
Docker blog [Scaling Docker to Serve Millions More Developers: Network Egress](https://www.docker.com/blog/scaling-docker-to-serve-millions-more-developers-network-egress/) announced pull rate limits to Docker subscription plans that will take effect 1 November 2020.

This PR adds Docker authentication to image pulls.

Uses CircleCI context docker-hub-creds to access environment variables.
